### PR TITLE
Added Redocly and Wechaty orgs back in list

### DIFF
--- a/2021-participants/interested-organizations.md
+++ b/2021-participants/interested-organizations.md
@@ -21,8 +21,11 @@ Project | Link to project ideas page
 [PCP](https://pcp.io) | [Task-based Guides for Performance Co-Pilot](https://pcp.io/gsod/2021/ideas.html)
 [PyTorch-Ignite](https://pytorch.org/ignite/) | ["Refresh our documentation and tutorials" proposal](https://github.com/pytorch/ignite/wiki/Google-Season-of-Docs-2021---Organization-Proposal)
 [Qubes OS](https://www.qubes-os.org) | [2021 GSoD Project Ideas](https://www.qubes-os.org/gsod/)
-[SymPy](https://www.sympy.org/en/index.html) | [Organization of SymPy Documentation](https://github.com/sympy/sympy/wiki/Google-Season-of-Docs)
 [Raku](https://raku.org) | [Raku documentation ideas](https://github.com/perl-foundation-outreach/season-of-docs-ideas)
-[WordPress](https://wordpress.org) | [Call for projects ideas for the Google Season of Docs 2021](https://make.wordpress.org/docs/2021/03/18/call-for-projects-ideas-for-the-google-season-of-docs-2021)
+[Redocly](https://redoc.ly/) | [Contribute to documenting Redocly's open-source tools](https://redoc.ly/gsod)
 [Sugar Labs](https://sugarlabs.org) | [Improve and update the lesson plans for Music Blocks](https://github.com/sugarlabs/GSoD)
+[SymPy](https://www.sympy.org/en/index.html) | [Organization of SymPy Documentation](https://github.com/sympy/sympy/wiki/Google-Season-of-Docs)
+[Wechaty](https://wechaty.js.org) | [Create easy to learn tutorials for beginner users of Wechaty](https://wechaty.js.org/docs/gsod/2021/)
+[WordPress](https://wordpress.org) | [Call for projects ideas for the Google Season of Docs 2021](https://make.wordpress.org/docs/2021/03/18/call-for-projects-ideas-for-the-google-season-of-docs-2021)
+
 


### PR DESCRIPTION
Redocly and Wechaty entries were accidentally deleted by a separate PR. Added them back in and also reordered list alphabetically.