### PR TITLE
Add Geomstats as an interested organization

### DIFF
--- a/2022-participants/interested-organizations.md
+++ b/2022-participants/interested-organizations.md
@@ -10,6 +10,7 @@ Project | Link to project ideas page
 ------- | ---------------------------
 [SAMPLE] [The GloriousPickle Project](https://example.com) | [2022 PickleDoc Ideas](https://example.com)
 [GeomScale](https://geomscale.github.io) | [2022 GeomScale Ideas](https://geomscale.github.io/GSoD-application/)
+[Geomstats](https://geomstats.github.io/) | [2022 Geomstats Ideas](https://github.com/geomstats/geomstats/blob/master/docs/gsod.rst)
 [The Julia Programming Language](https://julialang.org) | [2022 Julia Ideas](https://julialang.org/jsoc/gsod/projects/)
 [Redocly](https://redoc.ly/) | [Work on Redocly's open-source docs](https://redoc.ly/gsod-2022/)
 [Rocket.Chat](https://rocket.chat) | [2022 Rocket.Chat Ideas](https://docs.rocket.chat/contributors/google-season-of-docs/google-season-of-docs-2022)


### PR DESCRIPTION
This PR:
- adds the Python package Geomstats https://github.com/geomstats/geomstats in the list of interested organizations
- adds the link to the corresponding project page.